### PR TITLE
activity type fix

### DIFF
--- a/src/Calamity/Types/Model/Presence/Activity.hs
+++ b/src/Calamity/Types/Model/Presence/Activity.hs
@@ -28,11 +28,14 @@ data ActivityType
   | Streaming
   | Listening
   | Custom
-  deriving ( Eq, Generic, Show, Enum )
+  deriving ( Eq, Generic, Show )
   deriving ( TextShow ) via TSG.FromGeneric ActivityType
 
 instance ToJSON ActivityType where
-  toJSON t = Number $ fromIntegral (fromEnum t)
+  toJSON Game = Number 0
+  toJSON Streaming = Number 1
+  toJSON Listening = Number 2
+  toJSON Custom = Number 4
 
 instance FromJSON ActivityType where
   parseJSON = withScientific "ActivityType" $ \n -> case toBoundedInteger @Int n of
@@ -40,7 +43,7 @@ instance FromJSON ActivityType where
       0 -> pure Game
       1 -> pure Streaming
       2 -> pure Listening
-      3 -> pure Custom
+      4 -> pure Custom
       _ -> fail $ "Invalid ActivityType: " <> show n
     Nothing -> fail $ "Invalid ActivityType: " <> show n
 


### PR DESCRIPTION
Activity type fix (Custom).
Activity type is encoded as a number with values 0, 1, 2, 4.
https://discord.com/developers/docs/game-sdk/activities#data-models-activitytype-enum
It seems that this PR resolves the issue #27, but it's still a little bit odd that only the Guild Create event was affected.