### PR TITLE
Fix request body of EditOriginalInteractionResponse

### DIFF
--- a/calamity/Calamity/HTTP/Interaction.hs
+++ b/calamity/Calamity/HTTP/Interaction.hs
@@ -447,12 +447,7 @@ instance Request (InteractionRequest a) where
             , attachments = attachments
             , flags = flags
             }
-        jsonBody =
-          InteractionCallback
-            { type_ = UpdateMessageType
-            , data_ = Just . Aeson.toJSON $ jsonData
-            }
-    body <- reqBodyMultipart (partLBS "payload_json" (Aeson.encode jsonBody) : files)
+    body <- reqBodyMultipart (partLBS "payload_json" (Aeson.encode jsonData) : files)
     patchWith' body u o
   action (DeleteOriginalInteractionResponse _ _) = deleteWith
   action (CreateFollowupMessage _ _ cm) = \u o -> do


### PR DESCRIPTION
According to [documentation](https://discord.com/developers/docs/interactions/receiving-and-responding#edit-original-interaction-response), we won't need the `{ type, data }` part while using this endpoint